### PR TITLE
Bug: incorrect castlings after rook was captured

### DIFF
--- a/Sources/ChessKit/Game.swift
+++ b/Sources/ChessKit/Game.swift
@@ -215,6 +215,14 @@ public class Game {
             self.position.state.castlings = self.position.state.castlings
                 .filter { $0.color != self.position.state.turn || $0.kind != kind }
         }
+        
+        if let capturedPiece = self.position.board[move.to] {
+            if capturedPiece.kind == .rook {
+                let kind: PieceKind = move.to.file == 0 ? .queen : .king
+                self.position.state.castlings = self.position.state.castlings
+                    .filter { $0.color == self.position.state.turn || $0.kind != kind }
+            }
+        }
     }
     
     // MARK: Utilities


### PR DESCRIPTION
Check with FEN like "r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1"
Then white rook captures black rook. Both white and black castlings should change, resulting FEN should become like "R3k2r/8/8/8/8/8/8/4K2R w Kk - 0 1", but in fact it's still like "R3k2r/8/8/8/8/8/8/4K2R w Kkq - 0 1".