### PR TITLE
Update StandardRules.swift

### DIFF
--- a/Sources/ChessKit/Rules/StandardRules.swift
+++ b/Sources/ChessKit/Rules/StandardRules.swift
@@ -169,6 +169,11 @@ public class StandardRules: Rules {
             nextPosition.board[move.to] = nextPosition.board[move.from]
             nextPosition.board[move.from] = nil
             
+            // if move is en passant capture - remove captured pawn from board
+            if let enPassantCapturedPawn = self.squareOfEnPassantCapturedPawn(move: move, position: position) {
+                nextPosition.board[enPassantCapturedPawn] = nil
+            }
+            
             if self.isIllelgalCastling(move: move, position: position) {
                 return false
             }
@@ -177,6 +182,15 @@ public class StandardRules: Rules {
         }
         
         return moves.filter(filter)
+    }
+    
+    private func squareOfEnPassantCapturedPawn(move: Move, position: Position) -> Square? {
+        if let enPassant = position.state.enPasant {
+            if move.to.file == enPassant.file && move.to.rank == enPassant.rank {
+                return Square(file: enPassant.file, rank: enPassant.rank == 2 ? 3 : 4)
+            }
+        }
+        return nil
     }
     
     private func enumeratedPieces(for position: Position) -> [(Square, Piece)] {

--- a/Sources/ChessKit/Rules/StandardRules.swift
+++ b/Sources/ChessKit/Rules/StandardRules.swift
@@ -185,10 +185,11 @@ public class StandardRules: Rules {
     }
     
     private func squareOfEnPassantCapturedPawn(move: Move, position: Position) -> Square? {
-        if let enPassant = position.state.enPasant {
-            if move.to.file == enPassant.file && move.to.rank == enPassant.rank {
-                return Square(file: enPassant.file, rank: enPassant.rank == 2 ? 3 : 4)
-            }
+        guard let enPassant = position.state.enPasant else {
+            return
+        }
+        if move.to.file == enPassant.file && move.to.rank == enPassant.rank {
+            return Square(file: enPassant.file, rank: enPassant.rank == 2 ? 3 : 4)
         }
         return nil
     }

--- a/Sources/ChessKit/Rules/StandardRules.swift
+++ b/Sources/ChessKit/Rules/StandardRules.swift
@@ -186,7 +186,7 @@ public class StandardRules: Rules {
     
     private func squareOfEnPassantCapturedPawn(move: Move, position: Position) -> Square? {
         guard let enPassant = position.state.enPasant else {
-            return
+            return nil
         }
         if move.to.file == enPassant.file && move.to.rank == enPassant.rank {
             return Square(file: enPassant.file, rank: enPassant.rank == 2 ? 3 : 4)


### PR DESCRIPTION
Bug: legal moves does not return en passant capture for [fen](https://lichess.org/editor?fen=8%2F8%2F3p2k1%2FP2Pr1Pp%2F3R2KP%2F8%2F8%2F8+b+-+-+0+1)

Black made move h7h5, white should be able to make capture g5h6. But filterIllegal does filter out this move, because pawn captured with en passant is not removed from the board.

BTW, would be cool to rename all `enPasant` to `enPassant` throughout the project.